### PR TITLE
[Fix] Remove fvm description from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,1 @@
 # reliet
-
-## Getting Started
-
-### install FVM
-
-Please install FVM from [https://fvm.app/docs/getting_started/installation](https://fvm.app/docs/getting_started/installation)


### PR DESCRIPTION
## Background

### Current situation

- there is fvm description in README

### What the issue is

- fvm is not essential

## What you did to solve the issue

- remove the description
